### PR TITLE
Add a function to exit mario if the use key is pressed

### DIFF
--- a/lua/autorun/server/g64_sv_init.lua
+++ b/lua/autorun/server/g64_sv_init.lua
@@ -141,7 +141,7 @@ end)
 
 -- Exit mario if the use key is pressed
 hook.Add("KeyPress", "G64_EXIT_MARIO", function(ply, key)
-	if(IsValid(ply.MarioEnt)) and ( key == IN_USE ) then
+	if(IsValid(ply.MarioEnt)) and ( key == IN_RELOAD ) then
 		ply.MarioEnt:Remove()
 	end
 end)


### PR DESCRIPTION
As of now it's not possible to exit mario unless you have a kill bind, so I added a simple check if the use key is pressed so you can exit mario with a keypress.