### PR TITLE
Remember player's max health when mario is spawned

### DIFF
--- a/lua/autorun/server/g64_sv_init.lua
+++ b/lua/autorun/server/g64_sv_init.lua
@@ -16,7 +16,7 @@ util.AddNetworkString("G64_UPDATEREMOTECOLORS")
 util.AddNetworkString("G64_UPDATEREMOTECAP")
 util.AddNetworkString("G64_REQUESTCOLORS")
 util.AddNetworkString("G64_UPLOADCOLORS")
-util.AddNetworkString("G64_REMOVEINVALIDMARIO")
+util.AddNetworkString("G64_REMOVEINVALIDMARIO")	
 util.AddNetworkString("G64_CHANGESURFACEINFO")
 
 g64sv = {}
@@ -205,7 +205,7 @@ net.Receive("G64_MARIOGROUNDPOUND", function(len, ply)
 		d:SetDamageForce((target:GetPos() - mario:GetPos()) * 15000)
 		target:TakeDamageInfo(d)
 		mario:EmitSound("Flesh.ImpactHard", 75, 100, 1, CHAN_BODY)
-	elseif(target:GetPhysicsObject():IsValid()) then
+	elseif(IsValid(target) and target:GetPhysicsObject():IsValid()) then
 		local phys = target:GetPhysicsObject()
 		local forcedir = target:GetPos() - mario:GetPos()
 		local forcevec = forcedir:GetNormalized() * (300000 / forcedir:Length()) + Vector(0,0,4500)

--- a/lua/entities/g64_mario.lua
+++ b/lua/entities/g64_mario.lua
@@ -60,6 +60,7 @@ function ENT:Initialize()
 	
 	self.Owner = self:GetOwner()
 	self.OwnerHealth = self.Owner:Health()
+	self.OwnerMaxHealth = self.Owner:GetMaxHealth()
 	print(self.Owner:Alive())
 	if(self.Owner.IsMario == true || self.Owner:Alive() == false) then self:RemoveInvalid() return end
 	self.Owner.IsMario = true
@@ -154,6 +155,7 @@ function ENT:OnRemove()
 			end
 		else
 			self.Owner:SetObserverMode(OBS_MODE_NONE)
+			self.Owner:SetMaxHealth(self.OwnerMaxHealth)
 			self.Owner:SetHealth(self.OwnerHealth)
 			drive.PlayerStopDriving(self.Owner)
 			


### PR DESCRIPTION
Currently, the player's max health stays at 8 when Mario is removed. This (untested) PR should fix that.