### PR TITLE
Make camera behave based on opacity

### DIFF
--- a/lua/entities/g64_mario.lua
+++ b/lua/entities/g64_mario.lua
@@ -1503,7 +1503,7 @@ if CLIENT then
 
 			local newdist = dist / libsm64.ScaleFactor
 			local neworigin = view.origin - ply:EyeAngles():Forward() * newdist
-			local newmask = MASK_SOLID
+			local newmask = MASK_OPAQUE_AND_NPCS
 			if self.hasVanishCap == true then newmask = MASK_PLAYERSOLID_BRUSHONLY end
 			if self.marioAction == g64types.SM64MarioAction.ACT_DEBUG_FREE_MOVE then newmask = MASK_CURRENT end
 


### PR DESCRIPTION
Considers opacity instead of solidity for camera collision (this should work identically most of the time except in obvious cases where solidity is not equivalent to opacity).